### PR TITLE
Data_Plotting: Allow boxplot's col to be overriden

### DIFF
--- a/R/Data_Plotting.R
+++ b/R/Data_Plotting.R
@@ -18,11 +18,12 @@ plot.Data <- function(x, upq=0.9, lwq=0.1, outline = FALSE, ...) {
 #' @param lwq Lower quantile of TACs for min ylim
 #' @param ylim Optional numeric vector of length 2 to specify limits of y-axis.
 #' @param outline Logical. Include outliers in plot?
+#' @param col Optional colours to pass to \code{boxplot}
 #' @param ...  Optional additional arguments passed to \code{boxplot}
 #' @return Returns a data frame containing the information shown in the plot
 #' @author A. Hordyk
 #' @export
-boxplot.Data <- function(x, upq=0.9, lwq=0.1, ylim=NULL, outline = FALSE, ...) {
+boxplot.Data <- function(x, upq=0.9, lwq=0.1, ylim=NULL, outline = FALSE, col = NULL, ...) {
   Data <- updateMSE(x)
   if (class(Data) != "Data")  stop("Object must be of class 'Data'")
   tacs <- t(Data@TAC[, , 1])
@@ -51,7 +52,7 @@ boxplot.Data <- function(x, upq=0.9, lwq=0.1, ylim=NULL, outline = FALSE, ...) {
   }
   
   if (nMPs>1) {
-    cols <- rainbow(30)
+    if (is.null(col)) col <- rainbow(30)
     ord <- order(apply(tacs, 2, median, na.rm = TRUE))
     MPs <- MPs[ord]
     tacs <- tacs[, ord]
@@ -65,12 +66,12 @@ boxplot.Data <- function(x, upq=0.9, lwq=0.1, ylim=NULL, outline = FALSE, ...) {
     Median <- median(tacs)
     SD <- sd(tacs)
     tacs <- as.numeric(tacs)
-    cols <- "darkgray"
+    if (is.null(col)) col <- "darkgray"
   }
   
   par(mfrow = c(1, 1), oma = c(2, 4, 1, 0), mar = c(3, 3, 0, 0))
   if (nMPs>1) {
-    boxplot(tacs, names = MPs, las = 1, col = cols, outline = outline, 
+    boxplot(tacs, names = MPs, las = 1, col = col, outline = outline, 
           frame = FALSE, ylim = ylim, horizontal = TRUE, ...)
     if (units) mtext(paste("TAC (", Data@Units, ")", sep = ""), side = 1, outer = T, 
                      line = 0.5, cex = 1.25)
@@ -78,7 +79,7 @@ boxplot.Data <- function(x, upq=0.9, lwq=0.1, ylim=NULL, outline = FALSE, ...) {
                       line = 0.5, cex = 1.25)
     mtext(side = 2, "Management Procedures", outer = TRUE, line = 3, cex = 1.25)
   } else {
-    boxplot(tacs, names = MPs, las = 1, col = cols, outline = outline, 
+    boxplot(tacs, names = MPs, las = 1, col = col, outline = outline, 
             frame = FALSE, ylim = ylim, horizontal = FALSE, ...)
     if (units) mtext(paste("TAC (", Data@Units, ")", sep = ""), side = 2, outer = T, 
                      line = 0.5, cex = 1.25)

--- a/R/Data_Plotting.R
+++ b/R/Data_Plotting.R
@@ -88,7 +88,9 @@ boxplot.Data <- function(x, upq=0.9, lwq=0.1, ylim=NULL, outline = FALSE, col = 
     mtext(side = 3, MPs, outer = TRUE, line=-1, cex = 1.25, xpd=NA)
   }
  
-  if (units) data.frame(MP = MPs, Median = Median, SD = SD, Units = Data@Units)
-  if (!units) data.frame(MP = MPs, Median = Median, SD = SD)
-  
+  if (units) {
+      data.frame(MP = MPs, Median = Median, SD = SD, Units = Data@Units)
+  } else {
+      data.frame(MP = MPs, Median = Median, SD = SD)
+  }
 }


### PR DESCRIPTION
Hello!

We have found using DLMtool in some FarFish (https://www.farfish.eu/) workshops that colours in the TAC boxplot can be confusing, and people can relate green with good and red with bad. This would be easy to solve by passing ``col`` to set our own colour scheme, but as ``boxplot.Data`` sets it's own col we can't.

The following makes ``col`` a parameter for ``boxplot.Data`` so it can be overridden, much as you've done previously with ylim.

Thanks!