### PR TITLE
Fix documentation equation for SBT1

### DIFF
--- a/R/MPs_Output.R
+++ b/R/MPs_Output.R
@@ -3815,8 +3815,8 @@ class(Rcontrol2) <- "MP"
 #' For `SBT1` the TAC is calculated as:
 #'   \deqn{\textrm{TAC}_y = 
 #'              \left\{\begin{array}{ll} 
-#'              C_{y-1} (1+K_2\lambda) & \textrm{if } \lambda \geq 0 \\ 
-#'               C_{y-1} (1-K_1\lambda^\gamma) & \textrm{if } \lambda < 0\\ 
+#'              C_{y-1} (1+K_2 \left| \lambda \right| ) & \textrm{if } \lambda \geq 0 \\ 
+#'               C_{y-1} (1-K_1 \left| \lambda \right| ^\gamma) & \textrm{if } \lambda < 0\\ 
 #'              \end{array}\right.
 #'            }{}
 #'  where \eqn{\lambda} is the slope of index over the last `yrmsth` years, and 

--- a/R/MPs_Output.R
+++ b/R/MPs_Output.R
@@ -3815,8 +3815,8 @@ class(Rcontrol2) <- "MP"
 #' For `SBT1` the TAC is calculated as:
 #'   \deqn{\textrm{TAC}_y = 
 #'              \left\{\begin{array}{ll} 
-#'              C_{y-1} (1+K_2 \left| \lambda \right| ) & \textrm{if } \lambda \geq 0 \\ 
-#'               C_{y-1} (1-K_1 \left| \lambda \right| ^\gamma) & \textrm{if } \lambda < 0\\ 
+#'              C_{y-1} (1+K_2 \lvert \lambda \rvert ) & \textrm{if } \lambda \geq 0 \\ 
+#'               C_{y-1} (1-K_1 \lvert \lambda \rvert ^\gamma) & \textrm{if } \lambda < 0\\ 
 #'              \end{array}\right.
 #'            }{}
 #'  where \eqn{\lambda} is the slope of index over the last `yrmsth` years, and 


### PR DESCRIPTION
An alternative (as implemented in the code) would be to have `- \lambda` associated with K1 instead of the absolute value for both.