### PR TITLE
LBSPR policy is not recursive

### DIFF
--- a/R/MPs_Input.R
+++ b/R/MPs_Input.R
@@ -1108,7 +1108,7 @@ LBSPR <- function(x, Data, reps=1, plot=FALSE, SPRtarg=0.4, theta1=0.3,
 
   }
   Rec <- new("Rec")
-  Rec@Effort <- Eff
+  Rec@Effort <- Data@MPeff[x] * Eff   ## in the original paper LBSPR was used recursively.
   Rec@Misc$Ests <- runLBSPR$Ests
   Rec@Misc$Ests_smooth <- runLBSPR$Ests_smooth
   Rec


### PR DESCRIPTION
The older version of the DLMtool I was using had LBSPR affect effort recursively (as the paper also suggests, even though the old code was a bang-bang controller of sorts).
It seems like the new version doesn't accumulate delta efforts (V_t in the paper) so that in practice LBSPR's TAE really bounds effort only 5-10% of the time (usually on random spikes). I think without  recursivness LBSPR is basically a curE policy.


However I think my modification doesn't deal correctly with "reps" yet.